### PR TITLE
Prevent a BoundsError

### DIFF
--- a/src/dataframe/io.jl
+++ b/src/dataframe/io.jl
@@ -693,7 +693,7 @@ function findcorruption(rows::Integer,
     for i in 1:rows
         bound = p.lines[i + 1]
         f = 0
-        while p.bounds[t] < bound
+        while t <= n && p.bounds[t] < bound
             f += 1
             t += 1
         end


### PR DESCRIPTION
I triggered a BoundsError here, when loading a severely corrupted file.

This change is straightforward enough that I didn't bother reproducing the corrupted file (since then, I have fixed the file manually).